### PR TITLE
add -L/usr/local/lib to the LDFLAGS in zmq.go, to get linking

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -3,7 +3,7 @@ package zmq
 
 /*
 
-#cgo LDFLAGS: -lzmq
+#cgo LDFLAGS: -L/usr/local/lib -lzmq
 
 #include <zmq.h>
 #include <stdlib.h>


### PR DESCRIPTION
I had to add this flag to get linking on OSX, with zeromq installed via brew.
